### PR TITLE
Add CI workflow to validate action.yml

### DIFF
--- a/.github/workflows/check-action-metadata-task.yml
+++ b/.github/workflows/check-action-metadata-task.yml
@@ -1,0 +1,36 @@
+name: Check Action Metadata
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-action-metadata-task.yml"
+      - "action.yml"
+      - "Taskfile.yml"
+  pull_request:
+    paths:
+      - ".github/workflows/check-action-metadata-task.yml"
+      - "action.yml"
+      - "Taskfile.yml"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage from changes to the JSON schema.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Taskfile
+        uses: arduino/actions/setup-taskfile@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Validate action.yml
+        run: task action:validate

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # `arduino/setup-taskfile`
 
 [![Integration Tests status](https://github.com/arduino/setup-taskfile/actions/workflows/test-integration.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/test-integration.yml)
+[![Check Action Metadata status](https://github.com/arduino/setup-taskfile/actions/workflows/check-action-metadata-task.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-action-metadata-task.yml)
 [![Check License status](https://github.com/arduino/setup-taskfile/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-license.yml)
 
 This action makes the `task` binary available to Workflows.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,16 @@
+version: "3"
+
+vars:
+  ACTION_METADATA_SCHEMA_PATH: "$(mktemp -t github-action-schema-XXXXXXXXXX.json)"
+
+tasks:
+  check:
+    desc: Check for problems with the project
+    deps:
+      - task: action:validate
+
+  action:validate:
+    desc: Validate GitHub Actions metadata against JSON schema
+    cmds:
+      - wget --output-document={{ .ACTION_METADATA_SCHEMA_PATH }} https://json.schemastore.org/github-action
+      - npx ajv-cli validate --strict=false -s {{ .ACTION_METADATA_SCHEMA_PATH }} -d "action.yml"

--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,11 @@ author: 'Arduino'
 inputs:
   version:
     description: 'Version to use. Example: 3.4.2'
+    required: false
     default: '3.x'
   repo-token:
     description: "Token with permissions to do repo things"
+    required: false
 
 runs:
   using: 'node12'


### PR DESCRIPTION
On every push or pull request that affects the [action.yml](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions) GitHub Actions metadata file, and periodically, validate action.yml against [its JSON schema](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-action.json).
