### PR TITLE
Add CI workflow to check the license file

### DIFF
--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -1,0 +1,63 @@
+name: Check License
+
+env:
+  EXPECTED_LICENSE_FILENAME: LICENSE
+  # SPDX identifier: https://spdx.org/licenses/
+  EXPECTED_LICENSE_TYPE: 	GPL-3.0
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-license.yml"
+      # See: https://github.com/licensee/licensee/blob/master/docs/what-we-look-at.md#detecting-the-license-file
+      - "[cC][oO][pP][yY][iI][nN][gG]*"
+      - "[cC][oO][pP][yY][rR][iI][gG][hH][tH]*"
+      - "[lL][iI][cC][eE][nN][cCsS][eE]*"
+      - "[oO][fF][lL]*"
+      - "[pP][aA][tT][eE][nN][tT][sS]*"
+  pull_request:
+    paths:
+      - ".github/workflows/check-license.yml"
+      - "[cC][oO][pP][yY][iI][nN][gG]*"
+      - "[cC][oO][pP][yY][rR][iI][gG][hH][tH]*"
+      - "[lL][iI][cC][eE][nN][cCsS][eE]*"
+      - "[oO][fF][lL]*"
+      - "[pP][aA][tT][eE][nN][tT][sS]*"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check-license:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby # Install latest version
+
+      - name: Install licensee
+        run: gem install licensee
+
+      - name: Check license file
+        run: |
+          # See: https://github.com/licensee/licensee
+          LICENSEE_OUTPUT="$(licensee detect --json --confidence=100)"
+
+          DETECTED_LICENSE_FILE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].filename | tr --delete '\r')"
+          echo "Detected license file: $DETECTED_LICENSE_FILE"
+          if [ "$DETECTED_LICENSE_FILE" != "\"$EXPECTED_LICENSE_FILENAME\"" ]; then
+            echo "ERROR: detected license file doesn't match expected: $EXPECTED_LICENSE_FILENAME"
+            exit 1
+          fi
+
+          DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
+          echo "Detected license type: $DETECTED_LICENSE_TYPE"
+          if [ "$DETECTED_LICENSE_TYPE" != "\"$EXPECTED_LICENSE_TYPE\"" ]; then
+            echo "ERROR: detected license type doesn't match expected $EXPECTED_LICENSE_TYPE"
+            exit 1
+          fi

--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,3 @@
-This file includes licensing information for Arduino GitHub Actions.
-
-Copyright (c) 2019 ARDUINO SA
-
-The software is released under the GNU General Public License, which covers the main body
-of the [insert app name] code. The terms of this license can be found at:
-https://www.gnu.org/licenses/gpl-3.0.en.html
-
-You can be released from the requirements of the above licenses by purchasing
-a commercial license. Buying such a license is mandatory if you want to modify or
-otherwise use the software for commercial activities involving the Arduino
-software without disclosing the source code of your own applications. To purchase
-a commercial license, send an email to license@arduino.cc
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # setup-taskfile
 
+[![Check License status](https://github.com/arduino/setup-taskfile/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/setup-taskfile/actions/workflows/check-license.yml)
+
 This action makes the `task` binary available to Workflows.
 
 ## Usage

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,3 +1,15 @@
+// Copyright (c) 2019 ARDUINO SA
+//
+// The software is released under the GNU General Public License, which covers the main body
+// of the arduino/setup-taskfile code. The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to modify or
+// otherwise use the software for commercial activities involving the Arduino
+// software without disclosing the source code of your own applications. To purchase
+// a commercial license, send an email to license@arduino.cc
+
 import io = require("@actions/io");
 import path = require("path");
 import os = require("os");

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "setup"
   ],
   "author": "Arduino",
-  "license": "MIT",
+  "license": "GPL-3.0",
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/tool-cache": "^1.1.0",

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,3 +1,15 @@
+// Copyright (c) 2019 ARDUINO SA
+//
+// The software is released under the GNU General Public License, which covers the main body
+// of the arduino/setup-taskfile code. The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to modify or
+// otherwise use the software for commercial activities involving the Arduino
+// software without disclosing the source code of your own applications. To purchase
+// a commercial license, send an email to license@arduino.cc
+
 // Load tempDirectory before it gets wiped by tool-cache
 let tempDirectory = process.env["RUNNER_TEMP"] || "";
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,15 @@
+// Copyright (c) 2019 ARDUINO SA
+//
+// The software is released under the GNU General Public License, which covers the main body
+// of the arduino/setup-taskfile code. The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to modify or
+// otherwise use the software for commercial activities involving the Arduino
+// software without disclosing the source code of your own applications. To purchase
+// a commercial license, send an email to license@arduino.cc
+
 import * as core from "@actions/core";
 import * as installer from "./installer";
 


### PR DESCRIPTION
Whenever one of the recognized license file names are modified in the repository, the workflow runs [licensee](https://github.com/licensee/licensee) to check whether the license can be recognized and whether it is of the expected type.
