### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,7 @@
+---
+name: Bug report
+about: Report problems with the code in this repository.
+title: ""
+labels: "type: imperfection"
+assignees: ""
+---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+contact_links:
+  - name: Learn about GitHub Actions
+    url: https://docs.github.com/en/actions
+    about: Everything you need to know to get started with GitHub Actions.
+  - name: Learn about using the arduino/setup-taskfile action
+    url: https://github.com/arduino/setup-taskfile#readme
+    about: Detailed usage documentation is available here.
+  - name: Support request
+    url: https://forum.arduino.cc/
+    about: We can help you out on the Arduino Forum!

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,7 @@
+---
+name: Feature request
+about: Suggest an improvement for this project.
+title: ""
+labels: "type: enhancement"
+assignees: ""
+---


### PR DESCRIPTION
Although I don't feel that templates themselves have any value for this project, the GitHub template system has some very useful features:

- Template chooser allows redirecting support requests via "Contact Links", and also provides a prominent link to security policy to guide vulnerability disclosures.
- Encouragingg the reporter fit their report into a specific category results in more clarity.
- Automatic labeling according to template choice allows the reporter to do the initial classification.

Template chooser preview (missing the security policy link due to having been generated under my account):

![Clipboard01](https://user-images.githubusercontent.com/8572152/116965628-1d679700-ac63-11eb-907e-1a8ca30f0cd5.png)
