### PR TITLE
Change development policy to repackaging on every code change

### DIFF
--- a/.github/workflows/setup-taskflile.yml
+++ b/.github/workflows/setup-taskflile.yml
@@ -29,3 +29,29 @@ jobs:
 
       - name: npm test
         run: npm test
+
+  check-packaging:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build action
+        run: npm run build
+
+      - name: Package action
+        run: npm run pack
+
+      - name: Check packaging
+        # Ignoring CR because ncc's output has a mixture of line endings, while the repository should only contain
+        # Unix-style EOL.
+        run: git diff --ignore-cr-at-eol --color --exit-code dist

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -32,11 +32,6 @@ jobs:
       - name: Checkout local repository
         uses: actions/checkout@v2
 
-      - name: Build action
-        run: |
-          npm install
-          npm run build
-
       - name: Run action with defaults
         uses: ./ # Use the action from the local path.
 
@@ -68,11 +63,6 @@ jobs:
       - name: Checkout local repository
         uses: actions/checkout@v2
 
-      - name: Build action
-        run: |
-          npm install
-          npm run build
-
       - name: Run action, using Task minor version wildcard
         uses: ./
         with:
@@ -90,11 +80,6 @@ jobs:
     steps:
       - name: Checkout local repository
         uses: actions/checkout@v2
-
-      - name: Build action
-        run: |
-          npm install
-          npm run build
 
       - name: Run action, using invalid version
         id: setup-taskfile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,29 +1,57 @@
-## Development
+## Development workflow
 
-To work on the codebase you have to install all the dependencies:
+### 1. Install dependencies
 
-```sh
-# npm install
+```
+npm install
 ```
 
-To run the tests:
+### 2. Coding
 
-```sh
-# npm run test
+Now you're ready to work some [TypeScript](https://www.typescriptlang.org/) magic!
+
+Make sure to write or update tests for your work when appropriate.
+
+### 2. Format code
+
+Format the code to follow the standard style for the project:
+
 ```
+npm run format
+```
+
+### 3. Run tests
+
+Run the tests to ensure that the code works as expected:
+
+```
+npm run test
+```
+
+### 4. Build
+
+It is necessary to compile the code before it can be used by GitHub Actions. Remember to run these commands before committing any code changes:
+
+```
+npm run build
+npm run pack
+```
+
+### 3. Commit
+
+Everything is now ready to make your contribution to the project, so commit it to the repository and submit a pull request.
+
+Thanks!
 
 ## Enable verbose logging for a pipeline
 Additional log events with the prefix ::debug:: can be enabled by setting the secret `ACTIONS_STEP_DEBUG` to `true`.
 
 See [step-debug-logs](https://github.com/actions/toolkit/blob/master/docs/action-debugging.md#step-debug-logs) for reference.
 
-## Release
+## Release workflow
 
-To release a new version of the Action the workflow should be the following:
+Instructions for releasing a new version of the action:
 
-1. `npm install` to install the dependencies.
-1. `npm run test` to see everything works as expected.
-1. `npm run build` to build the Action under the `./lib` folder.
-1. `npm run pack` to package for distribution
-1. `git add src dist` to check in the code that matters.
-1. open a PR and request a review.
+1. If the release will increment the major version, update the action refs in the examples in README.md (e.g., `uses: arduino/setup-taskfile@v1` -> `uses: arduino/setup-taskfile@v2`).
+1. Create a [GitHub release](https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository#creating-a-release), following the `vX.Y.Z` tag name convention. Make sure to follow [the SemVer specification](https://semver.org/).
+1. Rebase the release branch for that major version (e.g., `v1` branch for the `v1.x.x` tags) on the tag. If no branch exists for the release's major version, create one.

--- a/dist/index.js
+++ b/dist/index.js
@@ -6,6 +6,17 @@
 
 "use strict";
 
+// Copyright (c) 2019 ARDUINO SA
+//
+// The software is released under the GNU General Public License, which covers the main body
+// of the arduino/setup-taskfile code. The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to modify or
+// otherwise use the software for commercial activities involving the Arduino
+// software without disclosing the source code of your own applications. To purchase
+// a commercial license, send an email to license@arduino.cc
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
@@ -204,6 +215,17 @@ function normalizeVersion(version) {
 
 "use strict";
 
+// Copyright (c) 2019 ARDUINO SA
+//
+// The software is released under the GNU General Public License, which covers the main body
+// of the arduino/setup-taskfile code. The terms of this license can be found at:
+// https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// You can be released from the requirements of the above licenses by purchasing
+// a commercial license. Buying such a license is mandatory if you want to modify or
+// otherwise use the software for commercial activities involving the Arduino
+// software without disclosing the source code of your own applications. To purchase
+// a commercial license, send an email to license@arduino.cc
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }


### PR DESCRIPTION
The previous development policy was to only repackage on each release. This prevented contributors from doing casual beta
testing by simply referencing the action as `arduino/setup-taskfile@main` in a workflow.

This policy change is implemented via:

- Update development and release workflow documentation.
- Add a CI job to check for forgotten packaging.
- Repackage the current code.
- Adjust the integration testing workflow to account for new policy.