### PR TITLE
Change description of default version example snippet to be realistic

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It will be convenient to use [`${{ secrets.GITHUB_TOKEN }}`](https://docs.github
 
 ## Usage
 
-To get the latest stable version of Task just add this step:
+To get the action's default version of Task just add this step:
 
 ```yaml
 - name: Install Taskfile


### PR DESCRIPTION
History shows that the previous description "latest stable version of Task" is not likely to be accurate over time.
Better to just be honest about what the action does.